### PR TITLE
Fix no-cache param appending to image url considering params existenc…

### DIFF
--- a/frontend/js/components/MediaField.vue
+++ b/frontend/js/components/MediaField.vue
@@ -461,7 +461,11 @@
           })
 
           // try to load the media thumbnail
-          this.img.src = this.media.thumbnail + '&no-cache'
+          let append = '?';
+          if (this.media.thumbnail.indexOf('?') > -1) {
+            append = '&';
+          }
+          this.img.src = this.media.thumbnail + append + 'no-cache'
         })
       },
       showDefaultThumbnail: function () {


### PR DESCRIPTION
…e (#261)

* Changed & for ? in parameter from thumbnail url

When using images from amazon, or trough varnish with `&no-cache` will resolve in a xml's or 404 not found request:

```
https://s3-eu-west-1.amazonaws.com/tpd/logos-domain/4a3199790000640005044e8e/255x0.png&no-cache
```

```
https://s3-eu-west-1.amazonaws.com/tpd/logos-domain/4a3199790000640005044e8e/255x0.png?no-cache
```

* Fixed issue with urls

* Fixed wrong name thumbnail